### PR TITLE
Applying dependency injection and mocked test

### DIFF
--- a/src/components/BrazilPanel.js
+++ b/src/components/BrazilPanel.js
@@ -13,7 +13,7 @@ const BrazilPanel = (props) => {
   useEffect(() => {
     const fetchCountry = async () => {
       const loadedContent = await props.loadContent(props.country);
-      setData(loadedContent);
+      setData(loadedContent.data);
       setLoaded(true);
     };
     fetchCountry();

--- a/src/components/BrazilPanel.js
+++ b/src/components/BrazilPanel.js
@@ -1,20 +1,19 @@
 import React, { useState, useEffect } from 'react';
 import { Grid, Paper, Typography, Icon } from '@material-ui/core';
 import Skeleton from '@material-ui/lab/Skeleton';
-import api from '../service/api';
 import common from '../styles/common';
 import dateParse from '../functions/dateParse';
 
-const BrazilPanel = () => {
+const BrazilPanel = (props) => {
   const [data, setData] = useState([]);
   const [loaded, setLoaded] = useState(false);
   const date = dateParse(data.updated_at);
   const classes = common();
+
   useEffect(() => {
     const fetchCountry = async () => {
-      const response = await api.get('/brazil');
-      const { data } = response.data;
-      setData(data);
+      const loadedContent = await props.loadContent(props.country);
+      setData(loadedContent);
       setLoaded(true);
     };
     fetchCountry();

--- a/src/screens/Dashboard.js
+++ b/src/screens/Dashboard.js
@@ -8,6 +8,7 @@ import {
 } from '../components';
 import common from '../styles/common';
 import VaccinationPanel from '../components/VaccinationPanel';
+import { brazilResume, DashboardService } from '../service/DashboardService';
 
 const Dashboard = () => {
   const classes = common();
@@ -24,7 +25,10 @@ const Dashboard = () => {
             spacing={2}
           >
             <Grid xs item>
-              <BrazilPanel />
+              <BrazilPanel
+                loadContent={DashboardService.resumeFrom}
+                country="/brazil"
+              />
             </Grid>
             <Grid xs item>
               <StatesPanel />

--- a/src/service/DashboardService.js
+++ b/src/service/DashboardService.js
@@ -1,0 +1,9 @@
+import api from './api';
+
+export const DashboardService = {
+  resumeFrom: async (country) => {
+    const response = await api.get(country);
+    // const { data } = response.data;
+    return response.data;
+  },
+};

--- a/src/tests/BrazilPanel.test.js
+++ b/src/tests/BrazilPanel.test.js
@@ -8,22 +8,24 @@ describe('Testing BrazilPanel Component', () => {
   let server;
 
   const dummyData = {
-    country: "Brazil",
-    cases: 1275291,
-    confirmed: 13013601,
-    deaths: 332752,
-    recovered: 11405558,
-    updated_at: "2021-04-06T03:20:48.000Z"
+    data: {
+      country: 'Brazil',
+      cases: 1275291,
+      confirmed: 13013601,
+      deaths: 332752,
+      recovered: 11405558,
+      updated_at: '2021-04-06T03:20:48.000Z',
+    },
   };
 
-  const mockLoadContent = async() => {
+  const mockLoadContent = async () => {
     return dummyData;
-  }
+  };
 
   beforeEach(() => {
     server = makeServer();
     server.logging = false;
-    render(<BrazilPanel loadContent={mockLoadContent} country="/brazil"/>);
+    render(<BrazilPanel loadContent={mockLoadContent} country="/brazil" />);
   });
 
   afterEach(() => {
@@ -55,7 +57,7 @@ describe('Testing BrazilPanel Component', () => {
     });
   });
 
-  it('Should render correct data at their places', async() => {
+  it('Should render correct data at their places', async () => {
     const casesValue = await screen.findByTestId('brazil-panel-cases-value');
     const deathsValue = await screen.findByTestId('brazil-panel-deaths-value');
     const recoveredValue = await screen.findByTestId(
@@ -63,9 +65,11 @@ describe('Testing BrazilPanel Component', () => {
     );
 
     await waitFor(() => {
-      expect(casesValue).toHaveTextContent(dummyData.confirmed.toString()); // Must be 'dummmyData.cases'?
-      expect(deathsValue).toHaveTextContent(dummyData.deaths.toString());
-      expect(recoveredValue).toHaveTextContent(dummyData.recovered.toString());
+      expect(casesValue).toHaveTextContent(dummyData.data.confirmed.toString()); // Must be 'dummmyData.cases'?
+      expect(deathsValue).toHaveTextContent(dummyData.data.deaths.toString());
+      expect(recoveredValue).toHaveTextContent(
+        dummyData.data.recovered.toString()
+      );
     });
   });
 });

--- a/src/tests/BrazilPanel.test.js
+++ b/src/tests/BrazilPanel.test.js
@@ -6,10 +6,24 @@ import { makeServer } from '../service/mock';
 
 describe('Testing BrazilPanel Component', () => {
   let server;
+
+  const dummyData = {
+    country: "Brazil",
+    cases: 1275291,
+    confirmed: 13013601,
+    deaths: 332752,
+    recovered: 11405558,
+    updated_at: "2021-04-06T03:20:48.000Z"
+  };
+
+  const mockLoadContent = async() => {
+    return dummyData;
+  }
+
   beforeEach(() => {
     server = makeServer();
     server.logging = false;
-    render(<BrazilPanel />);
+    render(<BrazilPanel loadContent={mockLoadContent} country="/brazil"/>);
   });
 
   afterEach(() => {
@@ -38,6 +52,20 @@ describe('Testing BrazilPanel Component', () => {
       expect(casesValue).toBeInTheDocument();
       expect(deathsValue).toBeInTheDocument();
       expect(recoveredValue).toBeInTheDocument();
+    });
+  });
+
+  it('Should render correct data at their places', async() => {
+    const casesValue = await screen.findByTestId('brazil-panel-cases-value');
+    const deathsValue = await screen.findByTestId('brazil-panel-deaths-value');
+    const recoveredValue = await screen.findByTestId(
+      'brazil-panel-recovered-value'
+    );
+
+    await waitFor(() => {
+      expect(casesValue).toHaveTextContent(dummyData.confirmed.toString()); // Must be 'dummmyData.cases'?
+      expect(deathsValue).toHaveTextContent(dummyData.deaths.toString());
+      expect(recoveredValue).toHaveTextContent(dummyData.recovered.toString());
     });
   });
 });


### PR DESCRIPTION
Para fazer um teste mockado, tive que inverter a dependência do componente.
Antes ele era responsável por carregar os dados e renderizá-los na tela. Mas, para isso, ele dependia de um serviço cujos valores mudavam com o tempo, impedindo de fazer um teste unitário.
Primeiro, eu desacoplei as responsabilidades: transformei a função que carrega os dados em um serviço e injetei o método através do props do componente.
Agora que o componente recebe o método que vai executar, eu mockei esse método para trazer valores fixos no teste. E, posteriormente, comparei se os campos de valores do componente se comportam como deveria.

Notei, entretanto, que o campo responsável pelos casos, recebe valores de um campo chamado 'confirmados' (como consta a imagem). Resolvendo o questionamento, está tudo resolvido.
Obs: passivo de otimização, já que não sei testar no react e tá dando um warning de 'act()'

![image](https://user-images.githubusercontent.com/20706303/113659844-50753580-9679-11eb-9039-42cab5df2735.png)
 